### PR TITLE
Fix: los tests rompen si el abb da segfault durante abb_destruir

### DIFF
--- a/abb_test.py
+++ b/abb_test.py
@@ -217,7 +217,7 @@ class TestABB(unittest.TestCase):
 
     if r:
       print("\n\nABB MURIÓ{}\n{}\n".format(" CON SEGMENTATION FAULT"
-                                           if r == -11 else "", self.msg if self.msg else ""),
+                                           if r == -11 else "", self.msg),
             file=sys.stderr)
       sys.stderr.write(self.proc.stderr.read())
     else:

--- a/abb_test.py
+++ b/abb_test.py
@@ -204,6 +204,7 @@ class TestABB(unittest.TestCase):
         return int(val)
 
   def setUp(self):
+    self.msg = None
     self.seq = []
     self.proc = subprocess.Popen(["valgrind", CMD_NAME],
                                  stdin=subprocess.PIPE,
@@ -216,7 +217,7 @@ class TestABB(unittest.TestCase):
 
     if r:
       print("\n\nABB MURIÓ{}\n{}\n".format(" CON SEGMENTATION FAULT"
-                                           if r == -11 else "", self.msg),
+                                           if r == -11 else "", self.msg if self.msg else ""),
             file=sys.stderr)
       sys.stderr.write(self.proc.stderr.read())
     else:
@@ -233,6 +234,7 @@ class TestLeaks(TestABB):
   Solo se ejecuta si las anteriores pasaron.
   """
   def setUp(self):
+    self.msg = None
     self.seq = []
     self.proc = subprocess.Popen(["valgrind", "--leak-check=full",
                                   "--track-origins=yes", CMD_NAME],


### PR DESCRIPTION
### Problema:

Durante el `tearDown()` de las pruebas se da por sentado que `self.msg` está definido. Sin embargo existe un caso en que esto no ocurre: si durante un `reset()` el código a probar tuviera un error terminante, nunca se habría setteado el mensaje y por lo tanto el print de `ABB_MURIO` jamás se imprime y el script falla con el mensaje:

```
Traceback (most recent call last):
  File "./abb_test.py", line 219, in tearDown
    if r == -11 else "", self.msg),
AttributeError: 'TestABB' object has no attribute 'msg'
```

### Solución:

Definir `self.msg` en el `setUp` de cada una de las pruebas, inicializándolo en `None`.