### PR TITLE
Set a message in reset(), pointing to possible problems in abb_destruir.

### DIFF
--- a/abb_test.py
+++ b/abb_test.py
@@ -186,7 +186,10 @@ class TestABB(unittest.TestCase):
 
   def reset(self):
     self.seq = []
-    return self._communicate("X")
+    (msg, self.msg) = (self.msg,
+                       "Posible fallo en abb_destruir().\n")
+    self._communicate("X")
+    self.msg = msg
 
   def _communicate(self, cmd, key=""):
     self.proc.stdin.write("{}{}\n".format(cmd, key))

--- a/abb_test.py
+++ b/abb_test.py
@@ -187,7 +187,7 @@ class TestABB(unittest.TestCase):
   def reset(self):
     self.seq = []
     (msg, self.msg) = (self.msg,
-                       "Posible fallo en abb_destruir().\n")
+                       "Posible fallo en abb_destruir() o abb_crear().\n")
     self._communicate("X")
     self.msg = msg
 


### PR DESCRIPTION
Muy bueno el fix.

Cambiaría el mensaje a "Posible fallo en abb_destruir() o abb_crear()". Como el reset hace ambas operaciones a la vez cualquiera de las dos que falle desencadena ese comportamiento.
De todos modos con el dump de valgrind se puede detecatar fácilmente en dónde fue que se produjo el error.